### PR TITLE
Fix roulette page visuals

### DIFF
--- a/app/games/lightning-roulette/page.tsx
+++ b/app/games/lightning-roulette/page.tsx
@@ -346,19 +346,11 @@ export default function LightningRoulettePage() {
             <div className="lg:col-span-2">
               <Card className="bg-gray-900 border-2 border-yellow-400 text-white">
                 <CardContent className="p-8">
-                  <div className="relative w-96 h-96 mx-auto mb-8">
+                  <div className="relative w-96 h-96 mx-auto mb-8 overflow-hidden">
                     {/* Wheel */}
                     <div
                       ref={wheelRef}
-                      className="absolute inset-0 rounded-full border-8 border-yellow-400"
-                      style={{
-                        background: `conic-gradient(${ROULETTE_NUMBERS.map(
-                          (num, idx) =>
-                            `${
-                              num.color === "red" ? "#dc2626" : num.color === "black" ? "#000000" : "#16a34a"
-                            } ${idx * (360 / 37)}deg ${(idx + 1) * (360 / 37)}deg`,
-                        ).join(", ")})`,
-                      }}
+                      className="absolute inset-0 rounded-full roulette-wheel"
                     >
                       {/* Numbers on wheel */}
                       {ROULETTE_NUMBERS.map((num, idx) => {

--- a/app/games/roulette/page.tsx
+++ b/app/games/roulette/page.tsx
@@ -304,17 +304,11 @@ export default function RoulettePage() {
             <div className="lg:col-span-2">
               <Card className="casino-card border-4 border-yellow-400 text-white">
                 <CardContent className="p-8">
-                  <div className="relative w-96 h-96 mx-auto mb-8">
+                  <div className="relative w-96 h-96 mx-auto mb-8 overflow-hidden">
                     {/* Wheel */}
                     <div
                       ref={wheelRef}
-                      className="absolute inset-0 rounded-full border-8 border-yellow-400 bg-gradient-to-br from-green-700 to-green-900"
-                      style={{
-                        background: `conic-gradient(${ROULETTE_NUMBERS.map(
-                          (num, idx) =>
-                            `${num.color === "red" ? "#dc2626" : num.color === "black" ? "#000000" : "#16a34a"} ${idx * (360 / 37)}deg ${(idx + 1) * (360 / 37)}deg`,
-                        ).join(", ")})`,
-                      }}
+                      className="absolute inset-0 rounded-full roulette-wheel"
                     >
                       {/* Numbers on wheel */}
                       {ROULETTE_NUMBERS.map((num, idx) => (


### PR DESCRIPTION
## Summary
- use `roulette-wheel` styles and hide overflow for wheel container

## Testing
- `npm run lint` *(fails: unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_688529181220832fae89c4292f5226f9