### PR TITLE
Add dopamine gradient theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -223,6 +223,24 @@ body {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 25%, #f093fb 50%, #f5576c 75%, #4facfe 100%);
 }
 
+.dopamine-gradient {
+  background: linear-gradient(60deg, #ff00cc, #333399, #00ff99, #ff6600, #00ccff);
+  background-size: 600% 600%;
+  animation: dopamineShift 8s ease-in-out infinite;
+}
+
+@keyframes dopamineShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
 .casino-table {
   background: radial-gradient(ellipse at center, #0d4f3c 0%, #0a3d2e 100%),
     linear-gradient(45deg, #0a3d2e 25%, transparent 25%), linear-gradient(-45deg, #0a3d2e 25%, transparent 25%),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,7 +92,7 @@ export default function HomePage() {
   ]
 
   return (
-    <div className="min-h-screen premium-gradient">
+    <div className="min-h-screen dopamine-gradient">
       <Navigation />
 
       {/* Hero Section */}


### PR DESCRIPTION
## Summary
- add `dopamine-gradient` with animated neon colours
- use the new gradient on the home page

## Testing
- `pnpm run build` *(fails: importing hook components without `use client` and JSX syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885292df440832fb06cec5c91d5cc22